### PR TITLE
add TimeFormat in CheckMe.js

### DIFF
--- a/plugins/CheckMe.js
+++ b/plugins/CheckMe.js
@@ -3,7 +3,7 @@ function checkme(e){
     if(e.raw_message == '我的统计'){
         if(NIL.XDB.wl_exsits(e.sender.user_id)){
             var pl = NIL.XDB.get_player(e.sender.user_id);
-            var str = `[${pl.xboxid}]\n加入次数：${pl.count.join}\n游玩时间：${pl.count.duration}`;
+            var str = `玩家名: ${pl.xboxid}\n进服次数: ${pl.count.join}\n游玩时间: ${timeFormat(pl.count.duration)} 小时`;
             e.reply(str);
         }else{
             e.reply('你还没绑定xboxid!',true);
@@ -11,7 +11,13 @@ function checkme(e){
     }
 }
 
-
+function timeFormat(dur){
+    if (dur!==0){
+        let hour=3600*10000;
+        return (dur/hour).toFixed(2);
+    }
+    return 0;
+}
 
 function onStart(){
     NIL.FUNC.PLUGINS.GROUP.push(checkme);


### PR DESCRIPTION
Considering that other player records need to use additional LL2.1 plug-ins, only time formatting is added, and more functions will be released separately on minbbs.